### PR TITLE
Fix cargo publishing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "twisterl"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 version = "0.1.0"
 description = "Minimal RL in Rust"
 authors = [{ name = "IBM Quantum+AI Team" }]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,8 @@
 name = "twisterl-rs"
 version = "0.1.0"
 edition = "2021"
+description = "Reinforcement learning primitives and a Python extension for high performance training and inference."
+license = "Apache-2.0"
 
 [features]
 python_bindings = ["pyo3"]


### PR DESCRIPTION
We need to add two fields to the `cargo.toml` to properly automate the crate publishing (I manually released version 0.1.0 and everything worked fine).
I also updated the minimum python to version 3.9 as it is currently the lowest one.
