### PR TITLE
Fix py versions in published wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -20,7 +20,13 @@ jobs:
           # Used for the ARM builds.
           - macos-15
           - windows-latest
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        exclude:
+          # torch wheels not available for macOS x86_64 on Python >= 3.13
+          - os: macos-15-intel
+            python-version: '3.13'
+          - os: macos-15-intel
+            python-version: '3.14'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
I updated only the ci file. This is the publish wheel update. Also, disabling mac-x64 for python>3.12 wheels as there no torch version for those.